### PR TITLE
Rails 5 compatibility

### DIFF
--- a/app/controllers/wat_catcher/bugsnag_controller.rb
+++ b/app/controllers/wat_catcher/bugsnag_controller.rb
@@ -1,6 +1,6 @@
 module WatCatcher
   class BugsnagController < ActionController::Base
-    skip_before_filter :verify_authenticity_token, only: :get
+    skip_before_filter :verify_authenticity_token, only: :get, raise: false
     include WatCatcher::CatcherOfWats
 
     def show

--- a/app/controllers/wat_catcher/wats_controller.rb
+++ b/app/controllers/wat_catcher/wats_controller.rb
@@ -1,6 +1,6 @@
 module WatCatcher
   class WatsController  < ActionController::Base
-    skip_before_filter :verify_authenticity_token, only: :create
+    skip_before_filter :verify_authenticity_token, only: :create, raise: false
 
     include WatCatcher::CatcherOfWats
 

--- a/lib/wat_catcher/version.rb
+++ b/lib/wat_catcher/version.rb
@@ -1,3 +1,3 @@
 module WatCatcher
-  VERSION = "0.10.2"
+  VERSION = "0.10.3"
 end


### PR DESCRIPTION
In Rails 5, skipping a filter whose method has yet to be defined results in an error. This update ensures that errors are not raised during app load.
