### PR TITLE
Fix Rails 5 deprecation warnings

### DIFF
--- a/app/controllers/wat_catcher/catcher_of_wats.rb
+++ b/app/controllers/wat_catcher/catcher_of_wats.rb
@@ -5,7 +5,7 @@ module WatCatcher
     extend ActiveSupport::Concern
 
     included do
-      around_filter :catch_wats
+      around_action :catch_wats
 
       helper_method :wat_user
     end
@@ -15,11 +15,11 @@ module WatCatcher
     end
 
     def disable_wat_report
-      env["wat_report_disabled"] = true
+      request.env["wat_report_disabled"] = true
     end
 
     def report_wat?
-      !!(env["wat_report"].present? && !env["wat_report_disabled"])
+      !!(request.env["wat_report"].present? && !request.env["wat_report_disabled"])
     end
 
     def catch_wats(&block)
@@ -29,7 +29,7 @@ module WatCatcher
       begin
         user = wat_user
       rescue;end
-      env["wat_report"] = {
+      request.env["wat_report"] = {
         request: request,
         user: user
       }


### PR DESCRIPTION
To fix "DEPRECATION WARNING: env is deprecated and will be removed from Rails 5.1" I replaced calls to 'env' with 'request.env' in CatcherOfWats per https://github.com/rails/rails/issues/23294.
To fix "DEPRECATION WARNING: around_filter is deprecated and will be removed in Rails 5.1. Use around_action instead." I replaced 'around_filter' with 'around_action' in CatcherOfWats.
