### PR TITLE
[#137051063] Add statsd instrumentation on WatCatcher::Report

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       coffee-rails
       httpclient
       rails (>= 4.2.0)
+      statsd-ruby
 
 GEM
   remote: https://rubygems.org/
@@ -76,7 +77,7 @@ GEM
       guard (>= 2.1.0)
       guard-compat (~> 1.1)
     guard-compat (1.2.1)
-    httpclient (2.8.2.4)
+    httpclient (2.8.3)
     i18n (0.7.0)
     jasmine (2.4.0)
       jasmine-core (~> 2.4)
@@ -173,6 +174,7 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.3.11)
+    statsd-ruby (1.3.0)
     thor (0.19.4)
     thread_safe (0.3.5)
     tzinfo (1.2.2)

--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ Alternatively, this can be configured in `config/application.rb` or environment 
 ```ruby
 module YourApp
   class Application < Rails::Application
-  Application configure do
     WatCatcher.configuration.statsd_host = "statsd.service.consul"
     WatCatcher.configuration.statsd_port = 9125
     WatCatcher.configuration.metrics_disabled = false

--- a/README.md
+++ b/README.md
@@ -66,6 +66,33 @@ YourApp::Application.configure do
 end
 ```
 
+#### Adding Telemetry
+In `config/wat_catcher.yml`:
+
+```yml
+production: &default
+  statsd_host: statsd.service.consul
+  statsd_port: 9125
+  metrics_disabled: false # defaults to true
+```
+
+Alternatively, this can be configured in `config/application.rb` or environment file (e.g. `config/environments/production.rb`).
+```ruby
+module YourApp
+  class Application < Rails::Application
+  Application configure do
+    WatCatcher.configuration.statsd_host = "statsd.service.consul"
+    WatCatcher.configuration.statsd_port = 9125
+    WatCatcher.configuration.metrics_disabled = false
+  end
+end
+```
+
+```ruby
+YourApp::Application.configure do
+  WatCatcher.configuration.metrics_disabled = false
+end
+```
 
 ### Mount the engine in your app for javascript errors
 To get around cross-origin issues, an engine was created that accepts POSTs of client exceptions and puts a sidekiq

--- a/lib/wat_catcher.rb
+++ b/lib/wat_catcher.rb
@@ -1,5 +1,7 @@
+require 'statsd'
 require "wat_catcher/version"
 
+require "wat_catcher/metrics"
 require "wat_catcher/report"
 require "wat_catcher/poster"
 require "wat_catcher/wattle_helper"

--- a/lib/wat_catcher/metrics.rb
+++ b/lib/wat_catcher/metrics.rb
@@ -11,8 +11,7 @@ module WatCatcher
     end
 
     def client
-      @client = ::Statsd.new @host, @port
-      @client
+      ::Statsd.new @host, @port
     end
 
     def increment(metric, sample_rate=1)

--- a/lib/wat_catcher/metrics.rb
+++ b/lib/wat_catcher/metrics.rb
@@ -1,0 +1,30 @@
+module WatCatcher
+  class Metrics
+    attr_writer :host, :port
+
+    def host
+      @host ||= 'localhost'
+    end
+
+    def port
+      @port ||= 9125
+    end
+
+    def client
+      @client = ::Statsd.new @host, @port
+      @client
+    end
+
+    def increment(metric, sample_rate=1)
+      client.increment metric, sample_rate
+    end
+
+    def decrement(metric, sample_rate=1)
+      client.increment metric, sample_rate
+    end
+
+    def set(metric, value, sample_rate=1)
+      client.set metric, value, sample_rate
+    end
+  end
+end

--- a/lib/wat_catcher/report.rb
+++ b/lib/wat_catcher/report.rb
@@ -36,7 +36,7 @@ module WatCatcher
     end
 
     def metrics_namespace
-      "#{base_description[:app_name]}.#{base_description[:app_env]}.".downcase
+      "#{base_description[:app_name]}.#{base_description[:app_env]}".downcase
     end
 
     def instrument_report

--- a/lib/wat_catcher/report.rb
+++ b/lib/wat_catcher/report.rb
@@ -9,6 +9,7 @@ module WatCatcher
       self.user = user
       send_report
       log_report
+      instrument_report unless metrics_disabled?
     end
 
     def send_report
@@ -19,6 +20,38 @@ module WatCatcher
     def log_report
       return if WatCatcher.configuration.disabled
       Rails.logger.error( "WatCatcher::error: " + base_description.tap {|x| x.delete(:rails_root) }.to_json )
+    end
+
+    def metrics_disabled?
+      WatCatcher.configuration.metrics_disabled = true if WatCatcher.configuration.metrics_disabled.nil?
+      WatCatcher.configuration.metrics_disabled
+    end
+
+    def metrics_reporter
+      @reporter ||= ::WatCatcher::Metrics.new
+      @reporter.host = WatCatcher.configuration.statsd_host
+      @reporter.port = WatCatcher.configuration.statsd_port
+
+      @reporter
+    end
+
+    def metrics_namespace
+      "#{base_description[:app_name]}.#{base_description[:app_env]}.".downcase
+    end
+
+    def instrument_report
+      return if WatCatcher.configuration.disabled
+
+      # increment graphite counter, ':' is used to seperate metric from metric value -- therefore, replace ':' with '_'
+      #   e.g. kairos.staging.exceptions.NoMethodError.frequency is count of `NoMethodError`s during sample period (60s)
+      #
+      # for application-aggregated
+      metrics_reporter.increment "#{metrics_namespace}.wat.#{exception_description[:error_class].gsub ':', '_'}.frequency"
+      # for server-aggregated
+      metrics_reporter.increment "#{metrics_namespace}.#{base_description[:hostname]}.wat.#{exception_description[:error_class].gsub ':', '_'}.frequency"
+
+      # emit an event that an exception was raised
+      metrics_reporter.set "#{metrics_namespace}.#{base_description[:hostname]}.wat.#{base_description[:error_class]}.occurance", base_description[:captured_at]
     end
 
     def params

--- a/wat_catcher.gemspec
+++ b/wat_catcher.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency     'coffee-rails'
   spec.add_runtime_dependency     'rails', '>= 4.2.0'
   spec.add_runtime_dependency     'httpclient'
+  spec.add_runtime_dependency     'statsd-ruby'
 end


### PR DESCRIPTION
Add instrumentation to `WatCatcher::Report`.

Uses the following configum:

| value | purpose | default |
| --- | --- | --- |
| statsd_host | Used to direct statsd client to collector hostname or IP | 'localhost' |
| statsd_port | Used to direct statsd client to collector port | 9125 |
| metrics_disabled | Used to toggle whether metrics are emitted | true |

I added this as an additional step to the constructor. It could alternatively be called from `#log_report`.