### PR TITLE
Support refraining from raising a wat until a retry count threshold has been met

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ Or install it yourself as:
 ### Configuration
 You can configure the wat_catcher in 2 ways; 1) via a config/wat_catcher.yml file or in ruby.
 
-Currently there are only 2 configuration options:
+Currently there are only 3 configuration options:
 host: This is the beginning of the url used to post wats to wattle.  It should look something like "https://yourwattleserver.com".
 disabled: If truthy this will stop any wats from being posted.
+sidekiq_retry_threshold: the number of retries that a job must be on before it raises a wat
 
 Here are 2 identical configs specified in the yml and in ruby.
 
@@ -31,6 +32,7 @@ config/wat_catcher.yml
 ```yml
 production: &default
   host: "https://wattle.yourhost.com"
+  sidekiq_retry_threshold: 4
 
 development:
   <<: *default
@@ -47,7 +49,8 @@ config/application.rb
 ```ruby
 module YourApp
   class Application < Rails::Application
-    WatCatcher.configuration.host =  "https://wattle.yourhost.com"
+    WatCatcher.configuration.host                    =  "https://wattle.yourhost.com"
+    WatCatcher.configuration.sidekiq_retry_threshold = 4
   end
 end
 ```

--- a/lib/wat_catcher/sidekiq_middleware.rb
+++ b/lib/wat_catcher/sidekiq_middleware.rb
@@ -17,12 +17,17 @@ module WatCatcher
 
         rescue
         end
-
-        WatCatcher::Report.new(excpt, user: u, sidekiq: msg)
+        WatCatcher::Report.new(excpt, user: u, sidekiq: msg) unless meets_threshold?(msg)
         raise
       end
     end
 
-  end
+    private
 
+    def meets_threshold?(retry_count)
+      return true if WatCatcher.configuration.sidekiq_retry_threshold.nil?
+      retry_count = msg['retry_count'].to_i
+      retry_count == 0 || retry_count >= WatCatcher.configuration.sidekiq_retry_threshold
+    end
+  end
 end


### PR DESCRIPTION
We have found that Wattle can get a little noisy with wats raised by Sidekiq jobs that failed on their first couple tries, then succeeded. (This is usually the case with jobs that rely on external services, such as HTTP APIs and mailers.) If those jobs wait until their Nth retry before raising a wat, life will be much more pleasant!