### PR TITLE
upgrade bugsnag.js to v3.1.0 and support reporting unhandled promise rejections

### DIFF
--- a/lib/wat_catcher/wattle_helper.rb
+++ b/lib/wat_catcher/wattle_helper.rb
@@ -14,7 +14,8 @@ module WatCatcher
                              data: {
                                endpoint: wat_catcher.bugsnag_path(::Rails.application.class.parent_name),
                                apiKey: "a"*32,
-                               user: wat_user.as_json
+                               user: wat_user.as_json,
+                               notifyUnhandledRejections: !!WatCatcher.configuration.notify_unhandled_promise_rejections
                              }
     end
   end


### PR DESCRIPTION
We checked that after upgrading bugsnag that we were still able to successfully send wats for unhandled javascript exceptions. In addition, we added support for unhandled promise rejections via a configuration option.