### PR TITLE
Support Rails 5.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    wat_catcher (0.10.10)
+    wat_catcher (0.10.11)
       coffee-rails
       httpclient
       rails (>= 4.2.0)
@@ -174,7 +174,7 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.3.11)
-    statsd-ruby (1.3.0)
+    statsd-ruby (1.4.0)
     thor (0.19.4)
     thread_safe (0.3.5)
     tzinfo (1.2.2)
@@ -196,4 +196,4 @@ DEPENDENCIES
   wat_catcher!
 
 BUNDLED WITH
-   1.13.6
+   1.14.6

--- a/app/controllers/wat_catcher/bugsnag_controller.rb
+++ b/app/controllers/wat_catcher/bugsnag_controller.rb
@@ -1,6 +1,6 @@
 module WatCatcher
   class BugsnagController < ActionController::Base
-    skip_before_filter :verify_authenticity_token, only: :get, raise: false
+    skip_before_action :verify_authenticity_token, only: :get, raise: false
     include WatCatcher::CatcherOfWats
 
     def show

--- a/app/controllers/wat_catcher/wats_controller.rb
+++ b/app/controllers/wat_catcher/wats_controller.rb
@@ -1,6 +1,6 @@
 module WatCatcher
   class WatsController  < ActionController::Base
-    skip_before_filter :verify_authenticity_token, only: :create, raise: false
+    skip_before_action :verify_authenticity_token, only: :create, raise: false
 
     include WatCatcher::CatcherOfWats
 

--- a/lib/wat_catcher/version.rb
+++ b/lib/wat_catcher/version.rb
@@ -1,3 +1,3 @@
 module WatCatcher
-  VERSION = "0.10.10"
+  VERSION = "0.10.11"
 end


### PR DESCRIPTION
Rails 5.1 removes some methods that had been previously deprecated. In wat_catcher's case, the skip_before_filter occurrences needed to be replaced with skip_before_action. Since skip_before_action has been around before Rails 4.2, and wat_catcher requires Rails >= 4.2, shouldn't be any clashes.